### PR TITLE
Add guard for Streamlit navigation API availability

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,31 @@ import streamlit as st
 
 
 # =========================
+# Streamlit runtime guard
+# =========================
+def _ensure_navigation_api() -> None:
+    """Fail fast with a helpful message when the nav API is unavailable."""
+
+    has_page = hasattr(st, "Page")
+    has_nav = hasattr(st, "navigation")
+    if has_page and has_nav:
+        return
+
+    version = getattr(st, "__version__", "unknown")
+    st.set_page_config(page_title="Senior Navigator", layout="wide")
+    st.error(
+        "Senior Navigator requires Streamlit 1.40 or newer so it can use the"
+        " built-in navigation API. The currently running Streamlit version"
+        f" is {version!r}. Please upgrade Streamlit (for example:"
+        " `pip install --upgrade streamlit>=1.40,<1.41`) and restart the app."
+    )
+    st.stop()
+
+
+_ensure_navigation_api()
+
+
+# =========================
 # Debug / guardrail toggles
 # =========================
 def _debug_enabled() -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.36,<1.41
+streamlit>=1.40,<1.41
 pandas>=2.1
 numpy>=1.25
 requests>=2.31


### PR DESCRIPTION
## Summary
- add a runtime guard that stops with a helpful message when the navigation API is missing
- bump the minimum supported Streamlit version to 1.40 to match the navigation API usage

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68e3362956608323a6c96dd0ecf9d4a0