### PR TITLE
Force Streamlit headless mode for hosted deployments

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,6 +1,15 @@
 [server]
-headless = false
+# Streamlit should always run in headless mode on hosted environments so
+# the CLI does not block waiting for interactive prompts (for example the
+# welcome email capture).  Running headless also mirrors how developers run
+# `streamlit run` locally.
+headless = true
 # remove enableCORS; Streamlit will set it safely with XSRF on
+
+[browser]
+# Disable usage stats prompts so Streamlit will not pause waiting for input
+# in non-interactive CI/container environments.
+gatherUsageStats = false
 
 [theme]
 primaryColor="#0b5cd8"


### PR DESCRIPTION
## Summary
- force Streamlit to run headless so hosted environments do not block on the onboarding prompt
- disable usage stats prompts to keep automated deploys from waiting for stdin input

## Testing
- streamlit run app.py

------
https://chatgpt.com/codex/tasks/task_b_68e3394936588323b957209673fbe16e