### PR TITLE
Polish documents and GCP styling

### DIFF
--- a/pages/my_documents.py
+++ b/pages/my_documents.py
@@ -28,45 +28,49 @@ if 'care_context' not in st.session_state:
 ctx = st.session_state.care_context
 
 # My Documents Page
-st.markdown('<div class="scn-hero">', unsafe_allow_html=True)
+st.markdown('<div class="documents-hero">', unsafe_allow_html=True)
 st.title("My Documents")
 st.markdown("<h2>Keep all of your loved one's records here.</h2>", unsafe_allow_html=True)
-st.markdown("<p>Safe storage for your care plans and more.</p>", unsafe_allow_html=True)
+st.markdown("<p class='max-ch'>Safe storage for your care plans and more.</p>", unsafe_allow_html=True)
 st.markdown('</div>', unsafe_allow_html=True)
 
 # Document tiles
-st.markdown('<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 2rem; justify-items: center; padding: 2rem;">', unsafe_allow_html=True)
+st.markdown('<div class="documents-grid">', unsafe_allow_html=True)
 
-# Care Plan Document
-st.markdown('<div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 2rem; text-align: left; min-height: 250px; background: #ffffff; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">', unsafe_allow_html=True)
-st.markdown("### Care Plan")
-st.markdown("<p>your loved one's guided care plan: Home care + VA benefits.</p>", unsafe_allow_html=True)
-st.button("View", key="view_care_doc", type="primary")
-st.button("Download", key="download_care_doc", type="secondary")
-st.markdown('</div>', unsafe_allow_html=True)
+documents = [
+    {
+        "title": "Care Plan",
+        "copy": "your loved one's guided care plan: Home care + VA benefits.",
+        "view_key": "view_care_doc",
+        "download_key": "download_care_doc",
+    },
+    {
+        "title": "Cost Summary",
+        "copy": "your loved one's budget: $1,500/month breakdown.",
+        "view_key": "view_cost_doc",
+        "download_key": "download_cost_doc",
+    },
+]
 
-# Cost Summary Document
-st.markdown('<div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 2rem; text-align: left; min-height: 250px; background: #ffffff; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">', unsafe_allow_html=True)
-st.markdown("### Cost Summary")
-st.markdown("<p>your loved one's budget: $1,500/month breakdown.</p>", unsafe_allow_html=True)
-st.button("View", key="view_cost_doc", type="primary")
-st.button("Download", key="download_cost_doc", type="secondary")
+for doc in documents:
+    st.markdown('<div class="documents-card card section">', unsafe_allow_html=True)
+    st.markdown(f"<h3>{doc['title']}</h3>", unsafe_allow_html=True)
+    st.markdown(f"<p class='documents-card__body max-ch'>{doc['copy']}</p>", unsafe_allow_html=True)
+    st.markdown('<div class="documents-card__actions">', unsafe_allow_html=True)
+    st.button("View", key=doc["view_key"], type="primary", use_container_width=True)
+    st.button("Download", key=doc["download_key"], type="secondary", use_container_width=True)
+    st.markdown('</div>', unsafe_allow_html=True)
+    st.markdown('</div>', unsafe_allow_html=True)
+
 st.markdown('</div>', unsafe_allow_html=True)
 
 # Upload Placeholder
-st.markdown('<div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 2rem; text-align: left; min-height: 250px; background: #ffffff; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">', unsafe_allow_html=True)
-st.markdown("### Upload Your Documents")
+st.markdown('<div class="documents-card card section documents-upload">', unsafe_allow_html=True)
+st.markdown("<h3>Upload Your Documents</h3>", unsafe_allow_html=True)
 st.markdown("<p>Add insurance forms, med lists, or notes for your loved one.</p>", unsafe_allow_html=True)
-st.button("Upload File", key="upload_doc", type="primary")
-st.markdown('</div>', unsafe_allow_html=True)
-
-st.markdown('</div>', unsafe_allow_html=True)
-
-# Navigation
-st.markdown('<div class="scn-nav-row">', unsafe_allow_html=True)
-col1, col2 = st.columns([1, 1])
-with col1:
-    st.button("Back to Hub", key="back_docs", type="secondary")
+st.button("Upload File", key="upload_doc", type="primary", use_container_width=True)
+st.markdown('<div class="documents-divider"></div>', unsafe_allow_html=True)
+st.button("Back to Hub", key="back_docs", type="secondary", use_container_width=True)
 st.markdown('</div>', unsafe_allow_html=True)
 
 st.markdown('</div>', unsafe_allow_html=True)

--- a/static/style.css
+++ b/static/style.css
@@ -5,6 +5,26 @@
 
 /* === Design Tokens === */
 :root {
+  --brand-primary: #0b5cd8;
+  --bg: #ffffff;
+  --bg-soft: #f6f8fa;
+  --text: #111418;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --pill: 9999px;
+  --shadow-sm: 0 1px 2px rgba(17, 20, 24, 0.06);
+  --shadow-md: 0 6px 24px rgba(17, 20, 24, 0.08);
+  --shadow-lg: 0 12px 40px rgba(17, 20, 24, 0.1);
+  --ring: 0 0 0 3px rgba(11, 92, 216, 0.25);
+  --gap-1: 8px;
+  --gap-2: 12px;
+  --gap-3: 16px;
+  --gap-4: 24px;
+  --gap-5: 32px;
+  --border: #e5e7eb;
+  --muted: #9aa3af;
+
   --font-base: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-display: "Plus Jakarta Sans", var(--font-base);
 
@@ -12,7 +32,7 @@
                    radial-gradient(circle at 88% 12%, rgba(14, 165, 233, 0.12) 0, rgba(14, 165, 233, 0) 52%),
                    linear-gradient(160deg, #eef2ff 0%, #f8faff 48%, #e0e7ff 100%);
 
-  --ink-900: #0f172a;
+  --ink-900: var(--text);
   --ink-700: #1e293b;
   --ink-500: #475569;
   --ink-300: #94a3b8;
@@ -20,37 +40,17 @@
   --surface-elevated: rgba(255, 255, 255, 0.96);
   --surface-muted: rgba(248, 250, 255, 0.68);
   --surface-border: rgba(148, 163, 184, 0.18);
-  --shadow-lg: 0 24px 60px -34px rgba(15, 23, 42, 0.6);
-  --shadow-md: 0 16px 42px -28px rgba(30, 41, 59, 0.48);
-  --shadow-sm: 0 12px 30px -24px rgba(30, 41, 59, 0.45);
 
-  --radius-md: 18px;
-  --radius-lg: 28px;
+  --ring-focus: var(--ring);
 
-  --ring-focus: 0 0 0 4px rgba(99, 102, 241, 0.24);
+  --btn-primary: var(--brand-primary);
+  --btn-primary-hover: #0a4db6;
+  --btn-secondary-bg: var(--bg-soft);
+  --btn-secondary-text: var(--text);
+  --btn-secondary-brd: var(--border);
 
-  /* Pill (Chip) Styles */
-  --pill-radius: 16px;
-  --pill-pad: 0.75rem 1.15rem;
-  --pill-gap: 0.85rem;
-  --pill-text: #1f2937;
-  --pill-bg: rgba(255, 255, 255, 0.9);
-  --pill-brd: rgba(99, 102, 241, 0.26);
-  --pill-hover: rgba(99, 102, 241, 0.12);
-  --pill-selected: #3730a3;
-  --pill-selected-hover: #1e1b4b;
-  --pill-shadow: 0 18px 32px -26px rgba(30, 41, 59, 0.66);
-  --pill-font: 16px;
-
-  /* Button Styles */
-  --btn-primary: #4f46e5;
-  --btn-primary-hover: #4338ca;
-  --btn-secondary-bg: rgba(79, 70, 229, 0.12);
-  --btn-secondary-text: #3730a3;
-  --btn-secondary-brd: rgba(79, 70, 229, 0.32);
-
-  --badge-bg: rgba(79, 70, 229, 0.12);
-  --badge-text: #3730a3;
+  --badge-bg: rgba(11, 92, 216, 0.1);
+  --badge-text: #0b5cd8;
 }
 
 /* === App Chrome === */
@@ -154,6 +154,377 @@ body, .stApp, [data-testid="stAppViewContainer"] {
 
 [data-testid="stSidebar"] .stMarkdown a {
   color: #c7d2fe;
+}
+
+/* === Global Utilities & Tokens === */
+.card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  transition: box-shadow 120ms ease, transform 120ms ease;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-1px);
+}
+
+.section {
+  padding: var(--gap-5);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--pill);
+  background: var(--bg);
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--text);
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+
+.pill:hover {
+  border-color: rgba(11, 92, 216, 0.35);
+  background: rgba(11, 92, 216, 0.08);
+}
+
+.pill.is-selected,
+.pill[data-selected="true"],
+.pill input:checked + span {
+  border-color: var(--brand-primary);
+  background: rgba(11, 92, 216, 0.08);
+  color: var(--brand-primary);
+  font-weight: 600;
+  box-shadow: var(--shadow-sm);
+}
+
+button.primary,
+.stButton button[kind="primary"],
+.stButton button[data-testid="baseButton-primary"],
+.stDownloadButton button[kind="primary"] {
+  background: var(--brand-primary);
+  color: #fff;
+  border-radius: var(--pill);
+  border: none;
+  min-height: 50px;
+  font-weight: 600;
+  box-shadow: var(--shadow-sm);
+  transition: background-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+button.primary:hover,
+.stButton button[kind="primary"]:hover,
+.stButton button[data-testid="baseButton-primary"]:hover,
+.stDownloadButton button[kind="primary"]:hover {
+  background: #094fc2;
+  box-shadow: var(--shadow-md);
+}
+
+button.secondary,
+.stButton button[kind="secondary"],
+.stButton button[data-testid="baseButton-secondary"],
+.stDownloadButton button[kind="secondary"] {
+  background: var(--bg-soft);
+  color: var(--text);
+  border-radius: var(--pill);
+  border: 1px solid var(--border);
+  min-height: 50px;
+  font-weight: 600;
+  transition: border-color 120ms ease, background-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+button.secondary:hover,
+.stButton button[kind="secondary"]:hover,
+.stButton button[data-testid="baseButton-secondary"]:hover,
+.stDownloadButton button[kind="secondary"]:hover {
+  border-color: rgba(17, 20, 24, 0.2);
+  background: #edf1f6;
+  box-shadow: var(--shadow-sm);
+}
+
+.stButton button,
+.stDownloadButton button {
+  width: 100%;
+  padding: 0 18px;
+}
+
+input,
+select,
+textarea,
+.stTextInput > div > div > input,
+.stSelectbox > div > div > div > input,
+.stSelectbox > div > div > div[data-baseweb="select"] {
+  min-height: 50px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: none;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+input::placeholder,
+textarea::placeholder,
+.stTextInput > div > div > input::placeholder {
+  color: var(--muted);
+}
+
+input:focus,
+select:focus,
+textarea:focus,
+.stTextInput > div > div > input:focus,
+.stSelectbox > div:focus-within {
+  outline: none;
+  border-color: var(--brand-primary);
+  box-shadow: var(--ring);
+}
+
+button:focus-visible,
+.stButton button:focus-visible,
+.stDownloadButton button:focus-visible,
+.pill:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
+}
+
+.max-ch {
+  max-width: 42ch;
+}
+
+/* === Welcome / Hero tweaks === */
+.sn-hero,
+.documents-hero {
+  display: grid;
+  gap: var(--gap-3);
+  margin-bottom: var(--gap-5);
+}
+
+.documents-hero p,
+.sn-hero p {
+  margin-bottom: var(--gap-4);
+  color: var(--muted);
+}
+
+/* === My Documents Page === */
+.documents-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--gap-4);
+  margin-bottom: var(--gap-5);
+}
+
+.documents-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-3);
+  min-height: 260px;
+}
+
+.documents-card h3 {
+  margin: 0;
+}
+
+.documents-card__body {
+  color: var(--muted);
+  margin: 0;
+}
+
+.documents-card__actions {
+  margin-top: auto;
+  display: flex;
+  flex-direction: row;
+  gap: var(--gap-3);
+}
+
+.documents-card__actions > div,
+.documents-card__actions .stButton,
+.documents-card__actions .stDownloadButton {
+  flex: 1;
+}
+
+.documents-divider {
+  border-top: 1px solid var(--border);
+  margin: var(--gap-5) 0 var(--gap-4);
+}
+
+.documents-upload button.primary,
+.documents-upload .stButton button[kind="primary"],
+.documents-upload .stButton button[data-testid="baseButton-primary"] {
+  min-height: 52px;
+}
+
+.documents-back {
+  margin-top: var(--gap-4);
+}
+
+/* === Guided Care Plan === */
+.gcp-section .card {
+  box-shadow: none;
+}
+
+.gcp-question.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-3);
+}
+
+.gcp-question__label {
+  margin: 0 0 var(--gap-2);
+  font-weight: 600;
+}
+
+.gcp-question__helper {
+  margin: -8px 0 var(--gap-2);
+  color: var(--muted);
+}
+
+.gcp-question .stRadio > div,
+.gcp-question .stCheckbox,
+.gcp-question .stMultiSelect {
+  width: 100%;
+}
+
+.gcp-question .stRadio > div[data-baseweb="radio"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-2);
+}
+
+.gcp-question .stRadio div[data-baseweb="radio"] label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: var(--pill);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+
+.gcp-question .stRadio div[data-baseweb="radio"] label:hover {
+  border-color: rgba(11, 92, 216, 0.35);
+  background: rgba(11, 92, 216, 0.08);
+}
+
+.gcp-question .stRadio div[data-baseweb="radio"] label input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.gcp-question .stRadio div[data-baseweb="radio"] label:has(input:checked) {
+  border-color: var(--brand-primary);
+  background: rgba(11, 92, 216, 0.08);
+  box-shadow: var(--shadow-sm);
+  color: var(--brand-primary);
+  font-weight: 600;
+}
+
+.gcp-question select,
+.gcp-question .stSelectbox > div > div {
+  min-height: 50px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+}
+
+.gcp-question .stSelectbox > div > div:focus-within {
+  box-shadow: var(--ring);
+  border-color: var(--brand-primary);
+}
+
+.gcp-question .stMultiSelect > div > div {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+}
+
+.gcp-question .stMultiSelect > div > div:focus-within {
+  box-shadow: var(--ring);
+  border-color: var(--brand-primary);
+}
+
+.gcp-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-4);
+}
+
+.gcp-section > div[data-testid="stVerticalBlock"] {
+  padding: 0;
+}
+
+.gcp-question.card.section {
+  padding: var(--gap-4);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  background: var(--bg);
+}
+
+.gcp-question.card.section:hover {
+  box-shadow: var(--shadow-lg);
+}
+
+.gcp-section .stDivider {
+  margin: 0;
+}
+
+/* === Focus & Contrast === */
+[data-testid="stHorizontalBlock"] > div {
+  gap: var(--gap-3);
+}
+
+.stMarkdown p {
+  color: var(--text);
+}
+
+.stCaption,
+.stMarkdown small,
+.stMarkdown em {
+  color: var(--muted);
+}
+
+.documents-grid .stMarkdown p {
+  color: var(--muted);
+}
+
+/* === Upload area === */
+.documents-upload .stMarkdown p {
+  color: var(--muted);
+}
+
+.documents-upload .documents-divider {
+  margin-top: var(--gap-5);
+}
+
+/* === Image stack === */
+.photo-stack img {
+  border: 4px solid #fff;
+  border-radius: 12px;
+  box-shadow: var(--shadow-md);
+}
+
+.photo-stack {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.photo-stack img + img {
+  transform: rotate(-2deg);
+}
+
+@media (max-width: 768px) {
+  .card.section {
+    padding: var(--gap-4);
+  }
+
+  .documents-card__actions {
+    flex-direction: column;
+  }
 }
 
 /* === Typography === */

--- a/ui/gcp_form.py
+++ b/ui/gcp_form.py
@@ -28,9 +28,10 @@ def render_question(q):
     if not _meets_visibility(q, data):
         return
 
-    st.markdown(f"**{q['label']}**")
+    st.markdown('<div class="gcp-question card section">', unsafe_allow_html=True)
+    st.markdown(f"<p class='gcp-question__label'>{q['label']}</p>", unsafe_allow_html=True)
     if q.get("helper"):
-        st.caption(q["helper"])
+        st.markdown(f"<p class='gcp-question__helper'>{q['helper']}</p>", unsafe_allow_html=True)
 
     if q["type"] == "single":
         idx = None
@@ -38,7 +39,14 @@ def render_question(q):
         labels = [lbl for _, lbl in q["choices"]]
         if qid in answers and answers[qid] in choice_ids:
             idx = choice_ids.index(answers[qid])
-        picked = st.radio("", labels, index=idx if idx is not None else 0, horizontal=False, key=f"gcp_{qid}_radio")
+        picked = st.radio(
+            "",
+            labels,
+            index=idx if idx is not None else 0,
+            horizontal=False,
+            key=f"gcp_{qid}_radio",
+            label_visibility="collapsed",
+        )
         answers[qid] = choice_ids[labels.index(picked)]
 
     elif q["type"] == "multi":
@@ -47,11 +55,19 @@ def render_question(q):
         preselect = []
         if qid in answers:
             preselect = [_label_for(q["choices"], v) for v in answers[qid]]
-        picked = st.multiselect("", labels, default=preselect, key=f"gcp_{qid}_multi")
+        picked = st.multiselect(
+            "",
+            labels,
+            default=preselect,
+            key=f"gcp_{qid}_multi",
+            label_visibility="collapsed",
+        )
         answers[qid] = [choice_ids[labels.index(lbl)] for lbl in picked]
         # mutually exclusive "none"
         if "none" in answers[qid] and len(answers[qid]) > 1:
             answers[qid] = ["none"]
+
+    st.markdown('</div>', unsafe_allow_html=True)
 
     # side effects after specific answers
     if qid == "medicaid_status":
@@ -63,10 +79,10 @@ def render_question(q):
             data["route"] = None
 
 def render_section(section_name: str, questions):
-    with st.container():
-        for q in questions:
-            render_question(q)
-            st.divider()
+    st.markdown('<div class="gcp-section">', unsafe_allow_html=True)
+    for q in questions:
+        render_question(q)
+    st.markdown('</div>', unsafe_allow_html=True)
 
 def nav_buttons(prev: str | None, nxt: str | None):
     cols = st.columns(2)


### PR DESCRIPTION
## Summary
- refreshed theme tokens and utility classes for shared buttons, pills, inputs, and section spacing
- reworked the My Documents page markup to use the new card, grid, and button utilities for consistent spacing and full-width actions
- restyled Guided Care Plan question blocks with card containers and chip-like radio controls

## Testing
- python -m compileall pages/my_documents.py ui/gcp_form.py

------
https://chatgpt.com/codex/tasks/task_b_68e34131ffe08323b0baf5991cad283a