### PR TITLE
Implement streamlined care navigator flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,8 @@ def _ensure_navigation_api() -> None:
 
 _ensure_navigation_api()
 
+from senior_nav.navigation import consume_pending_nav
+
 
 # =========================
 # Debug / guardrail toggles
@@ -161,6 +163,8 @@ def _syntax_preflight(paths=("pages",), stop_on_error=True):
             st.stop()
 _syntax_preflight()
 
+consume_pending_nav()
+
 # ==========================================
 # Session bootstrap (prototype auth flag)
 # ==========================================
@@ -184,64 +188,15 @@ def ensure_page(path: str, title: str, icon: str, default: bool = False):
 # ==========================================
 # Pages to register (controls nav order)
 # ==========================================
-INTENDED = [    ("pages/welcome.py", "Welcome", "👋", True),
-    ("pages/hub.py", "Your Concierge Care Hub", "🏠", False),
-    ("pages/SeniorNav_terms.py", "Terms of Use", "📄", False),
-    ("pages/SeniorNav_privacy.py", "Privacy Policy", "🔒", False),
-
-    ("pages/SeniorNav_welcome_self.py", "Welcome · For You", "🙂", False),
-    ("pages/SeniorNav_welcome_someone_else.py", "Welcome · Someone Else", "👥", False),
-    ("pages/SeniorNav_welcome_professional.py", "Welcome · Professional", "🩺", False),
-                ("pages/SeniorNav_professional_hub.py", "Professional Hub", "🧰", False),
-    ("pages/SeniorNav_ai_advisor.py", "AI Advisor", "🤖", False),
-    ("pages/SeniorNav_login.py", "Login", "🔐", False),
-    ("pages/SeniorNav_waiting_room.py", "Waiting Room", "⏳", False),
-    ("pages/SeniorNav_trusted_partners.py", "Trusted Partners", "🤝", False),
-    ("pages/SeniorNav_export_details.py", "Export Details", "📤", False),
-    ("pages/SeniorNav_my_documents.py", "My Documents", "📁", False),
-    ("pages/SeniorNav_my_account.py", "My Account", "👤", False),
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    ("pages/gcp_v2/gcp_landing_v2.py", "Guided Care Plan · Start", "🗺️", False),
-    ("pages/gcp_v2/gcp_daily_life_v2.py", "GCP · Daily Life & Support", "🧭", False),
-    ("pages/gcp_v2/gcp_health_safety_v2.py", "GCP · Health & Safety", "🩺", False),
-    ("pages/gcp_v2/gcp_context_prefs_v2.py", "GCP · Context & Preferences", "🎯", False),
-    ("pages/gcp_v2/gcp_recommendation_v2.py", "GCP · Recommendation", "✅", False),
-    ("pages/professional_mode.py", "Professional Mode", "🧑", False),
-    ("pages/expert_review.py", "Expert Review", "🔎", False),
-    ("pages/pfma.py", "Plan for My Advisor", "🧭", False),
-    ("pages/pfma_confirm_care_plan.py", "PFMA * Care Plan Confirmer", "✅", False),
-    ("pages/pfma_confirm_cost_plan.py", "PFMA * Cost Plan Confirmer", "💰", False),
-    ("pages/pfma_confirm_care_needs.py", "PFMA * Care Needs", "🩺", False),
-    ("pages/pfma_confirm_care_prefs.py", "PFMA * Care Preferences", "🎯", False),
-    ("pages/pfma_confirm_household_legal.py", "PFMA * Household & Legal", "🏠", False),
-    ("pages/pfma_confirm_benefits_coverage.py", "PFMA * Benefits & Coverage", "💳", False),
-    ("pages/pfma_confirm_personal_info.py", "PFMA * Personal Info", "👤", False),
-    ("pages/ai_advisor.py", "AI Advisor", "🤖", False),
-    ("pages/export_results.py", "Export Results", "📥", False),
-    ("pages/my_documents.py", "My Documents", "📁", False),
-    ("pages/my_account.py", "My Account", "👤", False),
-    ("pages/cost_planner_v2/cost_planner_landing_v2.py", "Cost Planner v2 · Landing", "💰", False),
-    ("pages/cost_planner_v2/cost_planner_modules_hub_v2.py", "Cost Planner v2 · Modules", "🧰", False),
-    ("pages/cost_planner_v2/cost_planner_income_v2.py", "Cost Planner v2 · Income", "🧾", False),
-    ("pages/cost_planner_v2/cost_planner_expenses_v2.py", "Cost Planner v2 · Expenses", "🧮", False),
-    ("pages/cost_planner_v2/cost_planner_benefits_v2.py", "Cost Planner v2 · Benefits", "🎖️", False),
-    ("pages/cost_planner_v2/cost_planner_home_v2.py", "Cost Planner v2 · Home", "🏠", False),
-    ("pages/cost_planner_v2/cost_planner_home_mods_v2.py", "Cost Planner v2 · Home Mods", "🔧", False),
-    ("pages/cost_planner_v2/cost_planner_liquidity_v2.py", "Cost Planner v2 · Liquidity", "💵", False),
-    ("pages/cost_planner_v2/cost_planner_caregiver_v2.py", "Cost Planner v2 · Caregiver", "👥", False),
-    ("pages/cost_planner_v2/cost_planner_assets_v2.py", "Cost Planner v2 · Assets", "🏦", False),
-    ("pages/cost_planner_v2/cost_planner_timeline_v2.py", "Cost Planner v2 · Timeline", "📈", False),
+INTENDED = [
+    ("pages/00_welcome.py", "Welcome", "👋", True),
+    ("pages/10_audiencing.py", "Choose Entry Type", "🎯", False),
+    ("pages/20_hub.py", "Care Planning Hub", "🏠", False),
+    ("pages/30_guided_care_plan.py", "Guided Care Plan", "🧭", False),
+    ("pages/40_cost_planner.py", "Cost Planner", "💰", False),
+    ("pages/50_my_documents.py", "My Documents", "📁", False),
+    ("pages/60_pfma.py", "Plan for My Advisor", "🤝", False),
+    ("pages/70_ai_advisor.py", "AI Advisor", "🤖", False),
 ]
 # Build the Page objects (ignore missing silently)
 pages = []

--- a/pages/00_welcome.py
+++ b/pages/00_welcome.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav import navigation
+from senior_nav.state import ensure_base_state
+from senior_nav.ui import set_page_config
+
+
+set_page_config(title="Welcome")
+ensure_base_state()
+
+if st.session_state.get("entry_ready"):
+    st.info("Welcome back! You're all set to continue planning.")
+    if st.button("Go to hub", type="primary"):
+        navigation.switch_page(navigation.HUB_PAGE)
+
+st.markdown(
+    """
+    <div style="max-width:720px;">
+      <h1>Senior Care Navigator</h1>
+      <p style="font-size:1.05rem;line-height:1.6;">
+        Answer a few questions, explore cost options, and share details with your concierge advisor.
+        Tell us who you're planning for and we'll tailor the experience.
+      </p>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
+
+with st.form("welcome_form"):
+    name = st.text_input(
+        "What's your name? (optional)",
+        value=st.session_state.get("visitor_name", ""),
+        placeholder="Alex",
+    )
+    submitted = st.form_submit_button("Continue", type="primary")
+
+if submitted:
+    st.session_state.visitor_name = name.strip()
+    st.session_state.entry_ready = True
+    navigation.switch_page(navigation.HUB_PAGE)

--- a/pages/10_audiencing.py
+++ b/pages/10_audiencing.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav import navigation
+from senior_nav.state import ensure_base_state, require_entry_ready
+from senior_nav.ui import header, render_ai_launcher, set_page_config
+
+
+set_page_config(title="Who are you planning for?")
+ensure_base_state()
+require_entry_ready()
+
+header("Who are you planning for?", "This helps tailor the questions and resources.")
+
+options = {
+    "For myself": "self",
+    "For someone else": "proxy",
+    "I'm a professional": "pro",
+}
+
+existing = st.session_state.get("entry_type")
+labels = list(options.keys())
+index = labels.index(next((label for label, key in options.items() if key == existing), labels[1])) if existing else 1
+
+with st.form("audiencing_form"):
+    choice_label = st.radio("Select the option that fits best", labels, index=index)
+    submitted = st.form_submit_button("Continue to guided plan", type="primary")
+
+if submitted:
+    st.session_state.entry_type = options[choice_label]
+    navigation.switch_page(navigation.GCP_PAGE)
+
+render_ai_launcher()

--- a/pages/20_hub.py
+++ b/pages/20_hub.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav import navigation
+from senior_nav.documents import list_documents
+from senior_nav.state import completions, ensure_base_state, require_entry_ready
+from senior_nav.ui import header, render_ai_launcher, set_page_config
+
+
+set_page_config(title="Care Planning Hub")
+ensure_base_state()
+require_entry_ready()
+flags = completions()
+
+visitor_name = st.session_state.get("visitor_name")
+hero = "Welcome back" if visitor_name else "Your concierge care hub"
+header(hero if not visitor_name else f"{hero}, {visitor_name}", "Pick up where you left off.")
+
+with st.container():
+    st.subheader("Planning modules")
+    col1, col2, col3 = st.columns(3)
+
+    with col1:
+        status = "Complete" if flags.get("gcp") else "Start here"
+        cta = "View plan" if flags.get("gcp") else "Begin plan"
+        if st.button(f"🧭 Guided Care Plan\n{status}", key="hub_gcp", use_container_width=True):
+            if st.session_state.get("entry_type"):
+                navigation.switch_page(navigation.GCP_PAGE)
+            else:
+                navigation.switch_page(navigation.AUDIENCING_PAGE)
+        st.caption("Answer step-by-step questions to capture needs and recommendations.")
+        st.caption(status)
+
+    with col2:
+        cp_ready = bool(st.session_state.get("gcp"))
+        cost_status = "Complete" if flags.get("cost_planner") else ("Ready" if cp_ready else "Locked")
+        disabled = not cp_ready
+        if st.button(
+            f"💰 Cost Planner\n{cost_status}",
+            key="hub_cost",
+            disabled=disabled,
+            use_container_width=True,
+        ):
+            navigation.switch_page(navigation.COST_PLANNER_PAGE)
+        st.caption("Estimate ongoing costs based on your care plan recommendations.")
+
+    with col3:
+        pfma_status = "Booked" if flags.get("pfma") else "Next step"
+        if st.button(
+            f"🤝 Plan for My Advisor\n{pfma_status}",
+            key="hub_pfma",
+            use_container_width=True,
+        ):
+            navigation.switch_page(navigation.PFMA_PAGE)
+        st.caption("Share updates and book time with your concierge advisor.")
+
+st.markdown("---")
+
+with st.container():
+    st.subheader("Documents")
+    docs = list_documents()
+    if not docs:
+        st.info("Your exported documents will appear here once you complete a module.")
+    else:
+        st.write(f"You have {len(docs)} document(s) ready to view.")
+        if st.button("Open My Documents", key="hub_docs"):
+            navigation.switch_page(navigation.DOCUMENTS_PAGE)
+
+render_ai_launcher()

--- a/pages/30_guided_care_plan.py
+++ b/pages/30_guided_care_plan.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav import navigation
+from senior_nav.documents import register_json
+from senior_nav.state import completions, ensure_base_state, require_entry_type
+from senior_nav.ui import header, render_ai_launcher, set_page_config
+
+
+set_page_config(title="Guided Care Plan")
+ensure_base_state()
+require_entry_type()
+flags = completions()
+
+entry_type = st.session_state.get("entry_type")
+header("Guided Care Plan", "Capture needs, safety, and funding in one place.")
+
+existing = st.session_state.get("gcp") or {}
+answers = existing.get("answers", {})
+
+with st.form("gcp_form"):
+    medicaid_choice = st.selectbox(
+        "Do you currently receive Medicaid benefits?",
+        ("Yes", "No", "Unsure"),
+        index=("Yes", "No", "Unsure").index(answers.get("medicaid_q0", "Unsure")) if answers.get("medicaid_q0") else 2,
+        help="We start with Medicaid to understand any coverage you may already have.",
+    )
+    living_setting = st.selectbox(
+        "Where is the person living today?",
+        (
+            "At home",
+            "With family",
+            "Independent living",
+            "Assisted living",
+            "Memory care",
+        ),
+        index=(
+            ("At home",
+             "With family",
+             "Independent living",
+             "Assisted living",
+             "Memory care")
+        ).index(answers.get("living_setting", "At home")) if answers.get("living_setting") else 0,
+    )
+    safety_level = st.select_slider(
+        "How much day-to-day support is needed?",
+        options=["Low", "Moderate", "High"],
+        value=answers.get("care_intensity", "Moderate"),
+    )
+    payment_context = st.selectbox(
+        "How do you expect to pay for care?",
+        (
+            "Private pay",
+            "Long-term care insurance",
+            "Medicaid",
+            "Medicare",
+            "Veterans benefits",
+        ),
+        index=(
+            ("Private pay",
+             "Long-term care insurance",
+             "Medicaid",
+             "Medicare",
+             "Veterans benefits")
+        ).index(existing.get("payment_context", "Private pay")) if existing.get("payment_context") else 0,
+    )
+    funding_confidence = st.slider(
+        "How confident do you feel about paying for this plan?",
+        min_value=0,
+        max_value=100,
+        value=int(float(existing.get("funding_confidence", 0.5)) * 100),
+        help="We'll use this to highlight the right cost planning mode.",
+    )
+    notes = st.text_area(
+        "Anything else we should know?",
+        value=answers.get("notes", ""),
+        placeholder="Share context such as diagnoses, risks, or preferences.",
+    )
+    submitted = st.form_submit_button("Save care plan", type="primary")
+
+if submitted:
+    funding_score = round(funding_confidence / 100, 2)
+    recommended_setting = "Memory care" if safety_level == "High" else (
+        "Assisted living" if safety_level == "Moderate" else "In-home support"
+    )
+
+    contract = {
+        "answers": {
+            "medicaid_q0": medicaid_choice,
+            "living_setting": living_setting,
+            "care_intensity": safety_level,
+            "notes": notes,
+            "entry_type": entry_type,
+        },
+        "recommended_setting": recommended_setting,
+        "care_intensity": safety_level,
+        "payment_context": payment_context,
+        "funding_confidence": funding_score,
+        "medicaid_unsure_flag": medicaid_choice == "Unsure",
+    }
+    st.session_state.gcp = contract
+    flags.mark("gcp", True)
+    register_json("care_plan", kind="care_plan", title="Care Plan", payload=contract)
+    st.success("Care plan saved. We'll take you back to the hub.")
+    navigation.switch_page(navigation.HUB_PAGE)
+
+render_ai_launcher()

--- a/pages/40_cost_planner.py
+++ b/pages/40_cost_planner.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav import navigation
+from senior_nav.documents import register_json
+from senior_nav.state import completions, ensure_base_state, require_entry_ready
+from senior_nav.ui import header, render_ai_launcher, set_page_config
+
+
+set_page_config(title="Cost Planner")
+ensure_base_state()
+require_entry_ready()
+flags = completions()
+
+header("Cost Planner", "Build a cost picture from your guided care plan.")
+
+contract = st.session_state.get("gcp")
+if not contract:
+    st.warning("Complete the Guided Care Plan first so we know which costs to model.")
+    if st.button("Go to Guided Care Plan", type="primary"):
+        navigation.switch_page(navigation.GCP_PAGE)
+    render_ai_launcher()
+    st.stop()
+
+recommended = contract.get("recommended_setting", "In-home support")
+intensity = contract.get("care_intensity", "Moderate")
+payment_context = contract.get("payment_context", "Private pay")
+confidence = float(contract.get("funding_confidence", 0.5))
+
+baseline_map = {
+    "In-home support": 2800,
+    "Assisted living": 4200,
+    "Memory care": 5600,
+}
+default_baseline = baseline_map.get(recommended, 3200)
+mode_index = 0 if confidence >= 0.6 else 1
+
+with st.expander("Care plan snapshot", expanded=True):
+    st.markdown(
+        f"**Recommended setting:** {recommended}  \\n**Care intensity:** {intensity}  \\n**Payment context:** {payment_context}"
+    )
+
+with st.form("cost_planner_form"):
+    planning_mode = st.radio(
+        "How would you like to plan costs?",
+        ("Guided plan", "Explore options"),
+        index=mode_index,
+    )
+    monthly_cost = st.number_input(
+        "Estimated monthly cost",
+        min_value=0,
+        value=int(st.session_state.get("cost_planner", {}).get("monthly_cost", default_baseline)),
+        step=100,
+        help="Start with a baseline that matches your recommended setting.",
+    )
+    monthly_income = st.number_input(
+        "Income & benefits covering costs",
+        min_value=0,
+        value=int(st.session_state.get("cost_planner", {}).get("monthly_income", 1800)),
+        step=100,
+    )
+    savings_to_use = st.number_input(
+        "Monthly savings you're willing to apply",
+        min_value=0,
+        value=int(st.session_state.get("cost_planner", {}).get("savings_to_use", 600)),
+        step=50,
+    )
+    submitted = st.form_submit_button("Save cost summary", type="primary")
+
+if submitted:
+    gap = max(monthly_cost - (monthly_income + savings_to_use), 0)
+    summary = {
+        "mode": planning_mode,
+        "monthly_cost": monthly_cost,
+        "monthly_income": monthly_income,
+        "savings_to_use": savings_to_use,
+        "uncovered_gap": gap,
+        "based_on": contract,
+    }
+    st.session_state.cost_planner = summary
+    flags.mark("cost_planner", True)
+    register_json("cost_summary", kind="cost_summary", title="Cost Summary", payload=summary)
+    st.success("Cost summary saved and added to My Documents.")
+    navigation.switch_page(navigation.HUB_PAGE)
+
+render_ai_launcher()

--- a/pages/50_my_documents.py
+++ b/pages/50_my_documents.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+
+from senior_nav import navigation
+from senior_nav.documents import list_documents, register_user_upload
+from senior_nav.state import ensure_base_state, require_entry_ready
+from senior_nav.ui import header, render_ai_launcher, set_page_config
+
+
+set_page_config(title="My Documents")
+ensure_base_state()
+require_entry_ready()
+
+header("My Documents", "View, download, and upload supporting files.")
+
+documents = list_documents()
+if not documents:
+    st.info("Your Care Plan and Cost Summary will appear here after you save them.")
+else:
+    for doc in documents:
+        with st.container(border=True):
+            st.markdown(f"### {doc.title}")
+            st.caption(f"Kind: {doc.kind} · Updated {doc.created_at}")
+            doc_path = Path(doc.path)
+            if doc_path.exists():
+                data = doc_path.read_bytes()
+                st.download_button(
+                    "Download",
+                    data=data,
+                    file_name=doc_path.name,
+                    mime=doc.metadata.get("mime", "application/octet-stream"),
+                    key=f"download_{doc.doc_id}",
+                )
+                if doc_path.suffix in {".json", ".txt"}:
+                    with st.expander("Preview"):
+                        try:
+                            st.code(doc_path.read_text("utf-8"), language="json")
+                        except Exception:
+                            st.write("(Binary file)")
+            else:
+                st.warning("Document file missing from disk. Try exporting again.")
+
+st.markdown("---")
+
+st.subheader("Upload a document")
+uploaded = st.file_uploader("Add a file to share with your advisor", type=None)
+if uploaded:
+    register_user_upload(uploaded.name, uploaded.getvalue(), mime_type=uploaded.type)
+    st.success(f"Uploaded {uploaded.name} to your documents.")
+    st.experimental_rerun()
+
+if st.button("Back to hub"):
+    navigation.switch_page(navigation.HUB_PAGE)
+
+render_ai_launcher()

--- a/pages/60_pfma.py
+++ b/pages/60_pfma.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import date, time
+
+import streamlit as st
+
+from senior_nav import navigation
+from senior_nav.state import completions, ensure_base_state, require_entry_ready
+from senior_nav.ui import header, render_ai_launcher, set_page_config
+
+
+set_page_config(title="Plan for My Advisor")
+ensure_base_state()
+require_entry_ready()
+flags = completions()
+
+header("Plan for My Advisor", "Share details and confirm your advisor appointment.")
+
+snapshot = st.session_state.get("gcp")
+if snapshot:
+    with st.expander("Care plan snapshot"):
+        st.json({k: v for k, v in snapshot.items() if k != "answers"})
+        st.markdown("**Medicaid question:** " + snapshot.get("answers", {}).get("medicaid_q0", "Unsure"))
+
+existing = st.session_state.get("pfma") or {}
+
+with st.form("pfma_form"):
+    appointment_date = st.date_input(
+        "Preferred appointment date",
+        value=existing.get("appointment_date", date.today()),
+    )
+    appointment_time = st.time_input(
+        "Preferred time",
+        value=existing.get("appointment_time", time(hour=11, minute=0)),
+    )
+    contact = st.text_input(
+        "Best phone or email",
+        value=existing.get("contact_info", ""),
+    )
+    notes = st.text_area(
+        "Notes for your advisor",
+        value=existing.get("notes", ""),
+        placeholder="Share goals, questions, or constraints.",
+    )
+    submitted = st.form_submit_button("Book appointment", type="primary")
+
+if submitted:
+    st.session_state.pfma = {
+        "appointment_date": appointment_date,
+        "appointment_time": appointment_time,
+        "contact_info": contact,
+        "notes": notes,
+    }
+    flags.mark("pfma", True)
+    st.success("Advisor appointment captured. Returning to the hub.")
+    navigation.switch_page(navigation.HUB_PAGE)
+
+render_ai_launcher()

--- a/pages/70_ai_advisor.py
+++ b/pages/70_ai_advisor.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from senior_nav import navigation
+from senior_nav.state import ensure_base_state
+from senior_nav.ui import header, set_page_config
+
+
+set_page_config(title="AI Advisor")
+ensure_base_state()
+header("AI Advisor", "Ask for guidance or jump to another step.")
+
+messages = st.session_state.setdefault("ai_messages", [])
+for message in messages:
+    with st.chat_message(message["role"]):
+        st.markdown(message["content"])
+
+prompt = st.chat_input("Ask the AI Advisor…")
+nav_target: str | None = None
+
+if prompt:
+    messages.append({"role": "user", "content": prompt})
+    response = "I noted that. You can continue exploring from the hub."
+    lower = prompt.lower()
+    if "cost" in lower:
+        response = "Opening the cost planner so you can review funding."
+        nav_target = navigation.COST_PLANNER_PAGE
+    elif "care plan" in lower or "guided" in lower:
+        response = "Taking you back to the Guided Care Plan."
+        nav_target = navigation.GCP_PAGE
+    elif "document" in lower or "download" in lower:
+        response = "Let's open your documents so you can review and share them."
+        nav_target = navigation.DOCUMENTS_PAGE
+    elif "advisor" in lower or "book" in lower:
+        response = "I'll take you to the advisor booking page."
+        nav_target = navigation.PFMA_PAGE
+    messages.append({"role": "assistant", "content": response})
+    st.session_state.ai_messages = messages
+
+if st.button("Back to hub"):
+    navigation.switch_page(navigation.HUB_PAGE)
+
+col1, col2, col3, col4 = st.columns(4)
+if col1.button("Guided Care Plan", use_container_width=True):
+    navigation.switch_page(navigation.GCP_PAGE)
+if col2.button("Cost Planner", use_container_width=True):
+    navigation.switch_page(navigation.COST_PLANNER_PAGE)
+if col3.button("My Documents", use_container_width=True):
+    navigation.switch_page(navigation.DOCUMENTS_PAGE)
+if col4.button("Advisor booking", use_container_width=True):
+    navigation.switch_page(navigation.PFMA_PAGE)
+
+if nav_target:
+    navigation.switch_page(nav_target)

--- a/senior_nav/documents.py
+++ b/senior_nav/documents.py
@@ -1,0 +1,110 @@
+"""Lightweight documents + exports registry for the simplified flows."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, MutableMapping, Optional
+import uuid
+
+import streamlit as st
+
+EXPORTS_DIR = Path("documents/exports")
+EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass
+class DocumentEntry:
+    doc_id: str
+    kind: str
+    title: str
+    path: Path
+    created_at: str
+    metadata: MutableMapping[str, object]
+
+    def to_dict(self) -> dict:
+        return {
+            "doc_id": self.doc_id,
+            "kind": self.kind,
+            "title": self.title,
+            "path": str(self.path),
+            "created_at": self.created_at,
+            "metadata": dict(self.metadata),
+        }
+
+    def __post_init__(self) -> None:
+        if isinstance(self.path, str):
+            self.path = Path(self.path)
+        if not isinstance(self.metadata, dict):
+            self.metadata = dict(self.metadata)
+
+
+def _registry() -> MutableMapping[str, dict]:
+    from .state import ensure_base_state
+
+    ensure_base_state()
+    return st.session_state.setdefault("documents_registry", {})
+
+
+def register_document(
+    doc_id: str,
+    *,
+    kind: str,
+    title: str,
+    content_bytes: bytes,
+    metadata: Optional[MutableMapping[str, object]] = None,
+) -> DocumentEntry:
+    """Register or update a document export on disk and in session."""
+
+    EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    safe_doc_id = doc_id.replace("/", "-")
+    suffix = metadata.get("ext", "json") if metadata else "json"
+    filename = f"{safe_doc_id}.{suffix}"
+    path = EXPORTS_DIR / filename
+    path.write_bytes(content_bytes)
+
+    entry = {
+        "doc_id": safe_doc_id,
+        "kind": kind,
+        "title": title,
+        "path": str(path),
+        "created_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "metadata": dict(metadata or {}),
+    }
+    registry = _registry()
+    registry[safe_doc_id] = entry
+    st.session_state.documents_registry = registry
+    return DocumentEntry(**entry)  # type: ignore[arg-type]
+
+
+def list_documents() -> List[DocumentEntry]:
+    registry = _registry()
+    entries = [DocumentEntry(**data) for data in registry.values()]  # type: ignore[arg-type]
+    return sorted(entries, key=lambda e: e.created_at, reverse=True)
+
+
+def get_document(doc_id: str) -> Optional[DocumentEntry]:
+    registry = _registry()
+    data = registry.get(doc_id)
+    if not data:
+        return None
+    return DocumentEntry(**data)  # type: ignore[arg-type]
+
+
+def register_json(doc_id: str, *, kind: str, title: str, payload: dict) -> DocumentEntry:
+    return register_document(
+        doc_id,
+        kind=kind,
+        title=title,
+        content_bytes=json.dumps(payload, indent=2, sort_keys=True).encode("utf-8"),
+        metadata={"ext": "json"},
+    )
+
+
+def register_user_upload(name: str, data: bytes, *, mime_type: str | None = None) -> DocumentEntry:
+    doc_id = f"user_upload_{uuid.uuid4().hex}"
+    metadata = {"ext": Path(name).suffix.lstrip("."), "mime": mime_type or "application/octet-stream"}
+    if not metadata["ext"]:
+        metadata["ext"] = "bin"
+    return register_document(doc_id, kind="user_upload", title=name, content_bytes=data, metadata=metadata)

--- a/senior_nav/navigation.py
+++ b/senior_nav/navigation.py
@@ -1,0 +1,43 @@
+"""Navigation helpers and canonical page paths."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import streamlit as st
+
+WELCOME_PAGE: Final[str] = "pages/00_welcome.py"
+AUDIENCING_PAGE: Final[str] = "pages/10_audiencing.py"
+HUB_PAGE: Final[str] = "pages/20_hub.py"
+GCP_PAGE: Final[str] = "pages/30_guided_care_plan.py"
+COST_PLANNER_PAGE: Final[str] = "pages/40_cost_planner.py"
+DOCUMENTS_PAGE: Final[str] = "pages/50_my_documents.py"
+PFMA_PAGE: Final[str] = "pages/60_pfma.py"
+AI_ADVISOR_PAGE: Final[str] = "pages/70_ai_advisor.py"
+
+
+@dataclass(frozen=True)
+class NavTarget:
+    path: str
+
+
+def switch_page(path: str) -> None:
+    """Attempt to switch pages and gracefully degrade when not available."""
+
+    try:
+        st.switch_page(path)  # type: ignore[attr-defined]
+    except Exception:
+        st.session_state["_sn_pending_nav"] = path
+        st.rerun()
+
+
+def consume_pending_nav() -> None:
+    """Run at the top-level to honour any deferred navigation requests."""
+
+    pending = st.session_state.pop("_sn_pending_nav", None)
+    if pending:
+        try:
+            st.switch_page(pending)  # type: ignore[attr-defined]
+        except Exception:
+            st.error("Navigation requires Streamlit 1.40 or newer.")
+            st.stop()

--- a/senior_nav/state.py
+++ b/senior_nav/state.py
@@ -1,0 +1,77 @@
+"""Session state helpers for the simplified Senior Navigator flow."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, MutableMapping
+
+import streamlit as st
+
+
+@dataclass
+class CompletionFlags:
+    """Simple view over module completion state."""
+
+    data: MutableMapping[str, bool] = field(default_factory=dict)
+
+    def get(self, key: str) -> bool:
+        return bool(self.data.get(key, False))
+
+    def mark(self, key: str, value: bool = True) -> None:
+        self.data[key] = bool(value)
+
+
+DEFAULT_STATE: Dict[str, Any] = {
+    "entry_ready": False,
+    "entry_type": None,
+    "visitor_name": "",
+    "gcp": None,
+    "cost_planner": {},
+    "pfma": None,
+    "documents_registry": {},
+    "completion": {},
+    "ai_messages": [],
+}
+
+
+def ensure_base_state() -> None:
+    """Populate baseline keys so downstream pages can rely on them."""
+
+    for key, value in DEFAULT_STATE.items():
+        if key in st.session_state:
+            continue
+        if isinstance(value, dict):
+            st.session_state[key] = dict(value)
+        elif isinstance(value, list):
+            st.session_state[key] = list(value)
+        else:
+            st.session_state[key] = value
+
+
+def completions() -> CompletionFlags:
+    """Return a lightweight adapter around completion flags."""
+
+    ensure_base_state()
+    data = st.session_state.setdefault("completion", {})
+    return CompletionFlags(data)
+
+
+def require_entry_ready() -> None:
+    """Redirect to the welcome page when a session has not started."""
+
+    ensure_base_state()
+    if not st.session_state.get("entry_ready"):
+        from .navigation import switch_page, WELCOME_PAGE
+
+        switch_page(WELCOME_PAGE)
+        st.stop()
+
+
+def require_entry_type() -> None:
+    """Ensure the audience selection has been made before continuing."""
+
+    require_entry_ready()
+    if not st.session_state.get("entry_type"):
+        from .navigation import AUDIENCING_PAGE, switch_page
+
+        switch_page(AUDIENCING_PAGE)
+        st.stop()

--- a/senior_nav/ui.py
+++ b/senior_nav/ui.py
@@ -1,0 +1,53 @@
+"""Shared UI helpers for the simplified Senior Navigator experience."""
+from __future__ import annotations
+
+import streamlit as st
+import streamlit.components.v1 as components
+
+from . import navigation
+
+
+def set_page_config(*, title: str) -> None:
+    st.set_page_config(page_title=title, layout="wide")
+
+
+def header(title: str, subtitle: str | None = None) -> None:
+    st.title(title)
+    if subtitle:
+        st.caption(subtitle)
+
+
+def render_ai_launcher() -> None:
+    """Render a floating button that opens the AI Advisor page."""
+
+    value = components.html(
+        """
+        <div class="sn-ai-launcher">
+          <button onclick="Streamlit.setComponentValue('open')">🤖 AI Advisor</button>
+        </div>
+        <style>
+          .sn-ai-launcher {
+            position: fixed;
+            bottom: 1.5rem;
+            right: 1.5rem;
+            z-index: 1000;
+          }
+          .sn-ai-launcher button {
+            background: #1d4ed8;
+            color: #fff;
+            border-radius: 999px;
+            padding: 0.65rem 1.4rem;
+            border: none;
+            font-weight: 600;
+            cursor: pointer;
+            box-shadow: 0 10px 30px rgba(29, 78, 216, 0.35);
+          }
+          .sn-ai-launcher button:hover {
+            background: #1e40af;
+          }
+        </style>
+        """,
+        height=0,
+    )
+    if value == "open":
+        navigation.switch_page(navigation.AI_ADVISOR_PAGE)


### PR DESCRIPTION
## Summary
- replace the legacy navigation registry with a focused set of core pages wired to the new session helpers
- add lightweight session, navigation, and document registries to keep guided care, cost planner, and PFMA data in sync
- build simplified Streamlit pages for the welcome, audience selection, hub, guided care plan, cost planner, documents, PFMA, and AI advisor experiences

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68e344d194c48323afa993b7426165e1