### PR TITLE
Update GCP v2 content for final question set

### DIFF
--- a/pages/gcp_v2/gcp_context_prefs_v2.py
+++ b/pages/gcp_v2/gcp_context_prefs_v2.py
@@ -9,5 +9,31 @@ inject_theme()
 
 st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
 st.markdown("## Context & Preferences")
-render_section("context_prefs", questions_for_section("context_prefs"))
+
+context_questions = questions_for_section("context_prefs")
+for question in context_questions:
+    if question["id"] == "chronic":
+        question["label"] = "Any chronic conditions we should plan for?"
+        question["helper"] = "Select all that apply."
+        question["choices"] = [
+            ("diabetes", "Diabetes"),
+            ("parkinson", "Parkinson’s"),
+            ("stroke", "Stroke"),
+            ("copd", "COPD"),
+            ("chf", "Heart failure (CHF)"),
+            ("other", "Other condition"),
+            ("none", "No chronic conditions"),
+        ]
+    elif question["id"] == "preferences":
+        question["label"] = "Any strong care preferences?"
+        question["helper"] = "Select all that apply."
+        question["choices"] = [
+            ("stay_home", "Stay at home"),
+            ("be_near_family", "Be near family"),
+            ("structured_care", "Structured community"),
+            ("private_room", "Private room"),
+            ("none", "No strong preferences"),
+        ]
+
+render_section("context_prefs", context_questions)
 nav_buttons("pages/gcp_v2/gcp_health_safety_v2.py", "pages/gcp_v2/gcp_recommendation_v2.py")

--- a/pages/gcp_v2/gcp_daily_life_v2.py
+++ b/pages/gcp_v2/gcp_daily_life_v2.py
@@ -9,5 +9,43 @@ inject_theme()
 
 st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
 st.markdown("## Daily Life & Support")
-render_section("daily_life_support", questions_for_section("daily_life_support"))
+
+daily_life_questions = questions_for_section("daily_life_support")
+for question in daily_life_questions:
+    if question["id"] == "who_for":
+        question["label"] = "Who are you planning for?"
+        question["choices"] = [
+            ("self", "Myself"),
+            ("parent", "Parent"),
+            ("spouse", "Spouse or partner"),
+            ("other", "Someone else"),
+        ]
+    elif question["id"] == "living_now":
+        question["label"] = "Where do they live today?"
+        question["choices"] = [
+            ("own_home", "In their own home"),
+            ("with_family", "With family"),
+            ("independent", "Independent/retirement community"),
+            ("assisted", "Assisted living"),
+            ("memory", "Memory care"),
+            ("skilled", "Skilled nursing"),
+        ]
+    elif question["id"] == "caregiver_support":
+        question["label"] = "How much caregiver support is available?"
+        question["choices"] = [
+            ("none", "No regular help"),
+            ("few_days_week", "Help a few days a week"),
+            ("most_days", "Help most days"),
+            ("24_7", "Help around the clock"),
+        ]
+    elif question["id"] == "adl_help":
+        question["label"] = "How many daily activities need hands-on help?"
+        question["choices"] = [
+            ("0-1", "0–1 activities"),
+            ("2-3", "2–3 activities"),
+            ("4-5", "4–5 activities"),
+            ("6+", "6 or more activities"),
+        ]
+
+render_section("daily_life_support", daily_life_questions)
 nav_buttons("pages/gcp_v2/gcp_landing_v2.py", "pages/gcp_v2/gcp_health_safety_v2.py")

--- a/pages/gcp_v2/gcp_health_safety_v2.py
+++ b/pages/gcp_v2/gcp_health_safety_v2.py
@@ -9,5 +9,55 @@ inject_theme()
 
 st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
 st.markdown("## Health & Safety")
-render_section("health_safety", questions_for_section("health_safety"))
+
+health_questions = questions_for_section("health_safety")
+for question in health_questions:
+    if question["id"] == "cognition":
+        question["label"] = "How is memory and thinking?"
+        question["choices"] = [
+            ("normal", "Sharp and consistent"),
+            ("mild", "Mild changes"),
+            ("moderate", "Noticeable confusion"),
+            ("severe", "Severe memory loss"),
+        ]
+    elif question["id"] == "behavior_risks":
+        question["label"] = "Any wandering or unsafe behaviors?"
+        question["helper"] = "Select all that apply."
+        question["choices"] = [
+            ("wandering", "Wandering"),
+            ("agitation", "Agitation or aggression"),
+            ("exit_seeking", "Tries to leave unsafely"),
+            ("none", "None of these"),
+        ]
+    elif question["id"] == "falls":
+        question["label"] = "Any falls in the last 12 months?"
+        question["choices"] = [
+            ("none", "No falls"),
+            ("one", "One fall"),
+            ("recurrent", "More than one fall"),
+        ]
+    elif question["id"] == "med_mgmt":
+        question["label"] = "How complex are medications to manage?"
+        question["choices"] = [
+            ("simple", "Simple routine"),
+            ("several", "Several medications"),
+            ("complex", "Complex schedule or frequent changes"),
+        ]
+    elif question["id"] == "home_safety":
+        question["label"] = "Is the home setup safe (stairs/bath/etc.)?"
+        question["choices"] = [
+            ("safe", "Safe setup"),
+            ("some_risks", "Some safety risks"),
+            ("unsafe", "Needs major safety support"),
+        ]
+    elif question["id"] == "supervision":
+        question["label"] = "Do they have the supervision they need at home?"
+        question["choices"] = [
+            ("always", "Always covered"),
+            ("sometimes", "Covered most of the time"),
+            ("rarely", "Covered occasionally"),
+            ("never", "Rarely or never covered"),
+        ]
+
+render_section("health_safety", health_questions)
 nav_buttons("pages/gcp_v2/gcp_daily_life_v2.py", "pages/gcp_v2/gcp_context_prefs_v2.py")

--- a/pages/gcp_v2/gcp_landing_v2.py
+++ b/pages/gcp_v2/gcp_landing_v2.py
@@ -12,7 +12,29 @@ st.markdown("## Guided Care Plan · Start")
 st.caption("We’ll begin with financial eligibility, then daily life, health & safety, and preferences.")
 
 # render financial section (Q0/Q1 with conditional logic)
-render_section("financial", questions_for_section("financial"))
+financial_questions = questions_for_section("financial")
+for question in financial_questions:
+    if question["id"] == "medicaid_status":
+        question["label"] = "Are you currently on Medicaid or receiving state long-term care assistance?"
+        question["helper"] = (
+            "Medicare is federal health insurance. Medicaid is a need-based program that can pay for long-term care. "
+            "If you’re unsure, keep going—we’ll flag this to double-check later."
+        )
+        question["choices"] = [
+            ("yes", "Yes"),
+            ("no", "No"),
+            ("unsure", "I'm not sure"),
+        ]
+    elif question["id"] == "funding_confidence":
+        question["label"] = "How confident do you feel about paying for care?"
+        question["choices"] = [
+            ("no_worries", "No worries"),
+            ("confident", "Confident"),
+            ("unsure", "Unsure"),
+            ("not_confident", "Not confident"),
+        ]
+
+render_section("financial", financial_questions)
 
 data = _state()
 if data.get("route") == "medicaid_offramp":

--- a/pages/gcp_v2/gcp_recommendation_v2.py
+++ b/pages/gcp_v2/gcp_recommendation_v2.py
@@ -3,29 +3,137 @@ import streamlit as st
 from ui.theme import inject_theme
 from ui.gcp_form import _state, nav_buttons
 
+VALUE_LABELS = {
+    "medicaid_status": {"yes": "Yes", "no": "No", "unsure": "I'm not sure"},
+    "funding_confidence": {
+        "no_worries": "No worries",
+        "confident": "Confident",
+        "unsure": "Unsure",
+        "not_confident": "Not confident",
+    },
+    "who_for": {
+        "self": "Myself",
+        "parent": "Parent",
+        "spouse": "Spouse or partner",
+        "other": "Someone else",
+    },
+    "living_now": {
+        "own_home": "In their own home",
+        "with_family": "With family",
+        "independent": "Independent/retirement community",
+        "assisted": "Assisted living",
+        "memory": "Memory care",
+        "skilled": "Skilled nursing",
+    },
+    "caregiver_support": {
+        "none": "No regular help",
+        "few_days_week": "Help a few days a week",
+        "most_days": "Help most days",
+        "24_7": "Help around the clock",
+    },
+    "adl_help": {
+        "0-1": "0–1 activities",
+        "2-3": "2–3 activities",
+        "4-5": "4–5 activities",
+        "6+": "6 or more activities",
+    },
+    "cognition": {
+        "normal": "Sharp and consistent",
+        "mild": "Mild changes",
+        "moderate": "Noticeable confusion",
+        "severe": "Severe memory loss",
+    },
+    "behavior_risks": {
+        "wandering": "Wandering",
+        "agitation": "Agitation or aggression",
+        "exit_seeking": "Tries to leave unsafely",
+        "none": "None of these",
+    },
+    "falls": {"none": "No falls", "one": "One fall", "recurrent": "More than one fall"},
+    "med_mgmt": {
+        "simple": "Simple routine",
+        "several": "Several medications",
+        "complex": "Complex schedule or frequent changes",
+    },
+    "home_safety": {
+        "safe": "Safe setup",
+        "some_risks": "Some safety risks",
+        "unsafe": "Needs major safety support",
+    },
+    "supervision": {
+        "always": "Always covered",
+        "sometimes": "Covered most of the time",
+        "rarely": "Covered occasionally",
+        "never": "Rarely or never covered",
+    },
+    "chronic": {
+        "diabetes": "Diabetes",
+        "parkinson": "Parkinson’s",
+        "stroke": "Stroke",
+        "copd": "COPD",
+        "chf": "Heart failure (CHF)",
+        "other": "Other condition",
+        "none": "No chronic conditions",
+    },
+    "preferences": {
+        "stay_home": "Stay at home",
+        "be_near_family": "Be near family",
+        "structured_care": "Structured community",
+        "private_room": "Private room",
+        "none": "No strong preferences",
+    },
+}
+
+
+def _format_answer(answers, question_id):
+    value = answers.get(question_id)
+    mapping = VALUE_LABELS.get(question_id, {})
+    if isinstance(value, list):
+        if not value:
+            return "(not set)"
+        return ", ".join(mapping.get(v, v) for v in value)
+    if value is None:
+        return "(not set)"
+    return mapping.get(value, value)
+
 st.set_page_config(layout="wide", page_title="GCP · Recommendation")
 inject_theme()
 
 st.markdown('<div class="sn-scope dashboard">', unsafe_allow_html=True)
-st.markdown("## Your Draft Recommendation")
+st.markdown("## Guided Care Plan · Recommendation")
+st.caption("Review the snapshot based on what you shared. You can adjust answers anytime and refresh this recommendation.")
 data = _state()
 ans = data.get("answers", {})
 ctx = data.get("payment_context", "private")
 
 if ctx == "medicaid":
-    st.warning("Based on your answer, Medicaid may be your best next step. We’ll connect you to the right off-ramp and keep your info for PFMA.")
+    st.warning(
+        "Based on what you shared, Medicaid may be your best next step. We’ll connect you to the Medicaid pathway and keep "
+        "your answers ready for Plan for My Advisor."
+    )
     nav_buttons("pages/gcp_v2/gcp_context_prefs_v2.py", "pages/pfma.py")
 else:
     st.markdown("### Snapshot")
+    st.markdown("Here’s a quick summary of your key details and care context.")
     col1, col2 = st.columns(2)
     with col1:
-        st.markdown("**Payment context:** Private")
-        st.markdown(f"**Funding confidence:** {ans.get('funding_confidence','(not set)')}")
-        st.markdown(f"**Who for:** {ans.get('who_for','(not set)')}")
-        st.markdown(f"**Current living:** {ans.get('living_now','(not set)')}")
+        st.markdown("**Payment focus:** Private pay")
+        st.markdown(f"**Funding confidence:** {_format_answer(ans, 'funding_confidence')}")
+        st.markdown(f"**Planning for:** {_format_answer(ans, 'who_for')}")
+        st.markdown(f"**Current living situation:** {_format_answer(ans, 'living_now')}")
+        st.markdown(f"**Caregiver support:** {_format_answer(ans, 'caregiver_support')}")
+        st.markdown(f"**Daily activities needing help:** {_format_answer(ans, 'adl_help')}")
     with col2:
-        st.markdown(f"**Cognition:** {ans.get('cognition','(not set)')}")
-        st.markdown(f"**Falls:** {ans.get('falls','(not set)')}")
-        st.markdown(f"**Med mgmt:** {ans.get('med_mgmt','(not set)')}")
-    st.info("This is a draft. Your advisor can refine it with you, then export via PFMA.")
+        st.markdown(f"**Memory & thinking:** {_format_answer(ans, 'cognition')}")
+        st.markdown(f"**Behavior risks:** {_format_answer(ans, 'behavior_risks')}")
+        st.markdown(f"**Falls history:** {_format_answer(ans, 'falls')}")
+        st.markdown(f"**Medication management:** {_format_answer(ans, 'med_mgmt')}")
+        st.markdown(f"**Home safety:** {_format_answer(ans, 'home_safety')}")
+        st.markdown(f"**Supervision coverage:** {_format_answer(ans, 'supervision')}")
+
+    st.markdown("### Additional context")
+    st.markdown(f"**Chronic conditions:** {_format_answer(ans, 'chronic')}")
+    st.markdown(f"**Care preferences:** {_format_answer(ans, 'preferences')}")
+
+    st.info("This is a draft summary. Your advisor can refine it with you and export via Plan for My Advisor.")
     nav_buttons("pages/gcp_v2/gcp_context_prefs_v2.py", "pages/pfma.py")


### PR DESCRIPTION
## Summary
- align the GCP v2 financial, daily life, health & safety, and context pages with the finalized question copy, help text, and choice labels
- refresh the recommendation page language and snapshot labels to reflect the updated answer text while preserving existing navigation

## Checklist
- [x] Guided Care Plan pages render the updated questions, helper copy, and option labels per the final spec
- [x] Guided Care Plan navigation, widget keys, and state wiring remain unchanged
- [x] Recommendation page copy reflects the new content guidance


------
https://chatgpt.com/codex/tasks/task_b_68e368918468832394c65b415e0c3c40