### PR TITLE
Fix Cost Planner v2 navigation paths

### DIFF
--- a/cost_planner_v2/cost_planner_modules_hub_v2.py
+++ b/cost_planner_v2/cost_planner_modules_hub_v2.py
@@ -12,24 +12,25 @@ st.markdown("### Your Plan Modules (v2)")
 st.caption("Work through modules in any order. Then view Your Money Timeline.")
 
 modules = [
-    ("Income", "cost_planner_income_v2.py"),
-    ("Other Monthly Costs", "cost_planner_expenses_v2.py"),
-    ("Caregiver Support", "cost_planner_caregiver_v2.py"),
-    ("Benefits", "cost_planner_benefits_v2.py"),
-    ("Home Decisions", "cost_planner_home_v2.py"),
-    ("Liquidity Nudge", "cost_planner_liquidity_v2.py"),
-    ("Home Modifications", "cost_planner_home_mods_v2.py"),
-    ("Assets", "cost_planner_assets_v2.py"),
+    ("Income", "pages/cost_planner_v2/cost_planner_income_v2.py"),
+    ("Other Monthly Costs", "pages/cost_planner_v2/cost_planner_expenses_v2.py"),
+    ("Caregiver Support", "pages/cost_planner_v2/cost_planner_caregiver_v2.py"),
+    ("Benefits", "pages/cost_planner_v2/cost_planner_benefits_v2.py"),
+    ("Home Decisions", "pages/cost_planner_v2/cost_planner_home_v2.py"),
+    ("Liquidity Nudge", "pages/cost_planner_v2/cost_planner_liquidity_v2.py"),
+    ("Home Modifications", "pages/cost_planner_v2/cost_planner_home_mods_v2.py"),
+    ("Assets", "pages/cost_planner_v2/cost_planner_assets_v2.py"),
 ]
 
 for label, page in modules:
     cols = st.columns([3,1])
     with cols[0]: st.write(f"**{label}**")
     with cols[1]:
-        if st.button("Open", key=f"open_{label}"): goto(page)
+        if st.button("Open", key=f"open_{label}"):
+            goto(page)
     st.divider()
 
 if st.button("View Money Timeline", type="primary"):
-    goto("cost_planner_timeline_v2.py")
+    goto("pages/cost_planner_v2/cost_planner_timeline_v2.py")
 
 st.markdown("</div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- update the legacy Cost Planner v2 module hub links to target the Streamlit page files under pages/cost_planner_v2
- point the Money Timeline shortcut to the fully qualified Streamlit path so it no longer raises a missing page error

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e375cf2af88323a5b0091318772a9b