### PR TITLE
Restore Cost Planner navigation

### DIFF
--- a/cost_planner_v2/cp_nav.py
+++ b/cost_planner_v2/cp_nav.py
@@ -1,7 +1,11 @@
-def goto(path: str):
-    import streamlit as st
-    try:
-        st.switch_page(path)
-    except Exception:
-        st.query_params["next"] = path
-        st.rerun()
+"""Navigation helpers for legacy cost planner modules."""
+
+from __future__ import annotations
+
+from senior_nav.navigation import switch_page
+
+
+def goto(path: str) -> None:
+    """Navigate to another Streamlit page, mirroring the global helper."""
+
+    switch_page(path)

--- a/senior_nav/cost_planner/wizard.py
+++ b/senior_nav/cost_planner/wizard.py
@@ -1,4 +1,5 @@
-"""Wizard registry and loader for the cost planner."""
+"""Helpers for navigating the Cost Planner v2 flow inside Streamlit."""
+
 from __future__ import annotations
 
 import importlib.util


### PR DESCRIPTION
## Summary
- point the Cost Planner navigation helper at the shared navigation.switch_page implementation so the modules redirect correctly with the Streamlit navigation API
- refresh the Cost Planner wizard module docstring to clarify its role managing the step registry

## Testing
- pytest tests/test_cp_ui_paths.py tests/test_cp_design_lint.py

------
https://chatgpt.com/codex/tasks/task_b_68e37b7a172c832382b0b59f138eea4b