### PR TITLE
Fix Cost Planner v2 navigation imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -236,6 +236,32 @@ INTENDED = [    ("pages/welcome.py", "Welcome", "👋", True),
     ("pages/cost_planner_v2/cost_planner_assets_v2.py", "Cost Planner v2 · Assets", "🏦", False),
     ("pages/cost_planner_v2/cost_planner_timeline_v2.py", "Cost Planner v2 · Timeline", "📈", False),
 ]
+# --- Cost Planner v2 diagnostics (non-blocking) ---
+_CP_V2_PREFIX = "pages/cost_planner_v2/"
+_cp_entries = [entry for entry in INTENDED if entry[0].startswith(_CP_V2_PREFIX)]
+_cp_missing: list[str] = []
+_cp_failed: list[tuple[str, str]] = []
+for path, title, icon, default in _cp_entries:
+    page_path = Path(path)
+    if not page_path.exists():
+        _cp_missing.append(path)
+        continue
+    try:
+        st.Page(path, title=title, icon=icon, default=default)
+    except Exception as exc:  # pragma: no cover - Streamlit runtime only
+        _cp_failed.append((path, f"{type(exc).__name__}: {exc}"))
+
+if _cp_missing or _cp_failed:
+    st.warning("Cost Planner v2 diagnostics detected issues. See details below.")
+    if _cp_missing:
+        st.write("**Missing on disk:**")
+        st.write("\n".join(f"• {p}" for p in sorted(_cp_missing)))
+    if _cp_failed:
+        st.write("**Failed to build:**")
+        for path, message in _cp_failed:
+            st.code(f"{path}\n{message}")
+else:
+    st.caption(f"Cost Planner v2 diagnostics: {len(_cp_entries)} page(s) ready.")
 # Build the Page objects (ignore missing silently)
 pages = []
 for path, title, icon, default in INTENDED:

--- a/cost_planner_v2/__init__.py
+++ b/cost_planner_v2/__init__.py
@@ -1,1 +1,27 @@
-# package marker
+"""Cost Planner v2 package bootstrap helpers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _ensure_shared_module() -> None:
+    """Expose the Streamlit page helpers as ``cost_planner_v2._shared``."""
+
+    module_name = "pages.cost_planner_v2._shared"
+    try:
+        shared_module = importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        # Leave a lightweight breadcrumb for diagnostics without crashing startup.
+        print(f"⚠️  cost_planner_v2: unable to import {module_name}")
+        return
+
+    alias = f"{__name__}._shared"
+    sys.modules.setdefault(alias, shared_module)
+    globals().setdefault("_shared", shared_module)
+
+
+_ensure_shared_module()
+
+__all__ = ["_shared"]

--- a/pages/cost_planner_v2/cost_planner_assets_v2.py
+++ b/pages/cost_planner_v2/cost_planner_assets_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from ui.theme import inject_theme
 

--- a/pages/cost_planner_v2/cost_planner_benefits_v2.py
+++ b/pages/cost_planner_v2/cost_planner_benefits_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from senior_nav.components.choice_chips import choice_single
 from ui.theme import inject_theme

--- a/pages/cost_planner_v2/cost_planner_caregiver_v2.py
+++ b/pages/cost_planner_v2/cost_planner_caregiver_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from senior_nav.components.choice_chips import choice_single
 from ui.theme import inject_theme

--- a/pages/cost_planner_v2/cost_planner_expenses_v2.py
+++ b/pages/cost_planner_v2/cost_planner_expenses_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from senior_nav.components.choice_chips import choice_single
 from ui.theme import inject_theme

--- a/pages/cost_planner_v2/cost_planner_home_mods_v2.py
+++ b/pages/cost_planner_v2/cost_planner_home_mods_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from senior_nav.components.choice_chips import choice_single
 from ui.theme import inject_theme

--- a/pages/cost_planner_v2/cost_planner_home_v2.py
+++ b/pages/cost_planner_v2/cost_planner_home_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from senior_nav.components.choice_chips import choice_single
 from ui.theme import inject_theme

--- a/pages/cost_planner_v2/cost_planner_income_v2.py
+++ b/pages/cost_planner_v2/cost_planner_income_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from senior_nav.components.choice_chips import choice_single
 from ui.theme import inject_theme

--- a/pages/cost_planner_v2/cost_planner_landing_v2.py
+++ b/pages/cost_planner_v2/cost_planner_landing_v2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import streamlit as st
 
 from cost_planner_v2.cp_nav import goto
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from ui.theme import inject_theme
 

--- a/pages/cost_planner_v2/cost_planner_liquidity_v2.py
+++ b/pages/cost_planner_v2/cost_planner_liquidity_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from ui.theme import inject_theme
 

--- a/pages/cost_planner_v2/cost_planner_modules_hub_v2.py
+++ b/pages/cost_planner_v2/cost_planner_modules_hub_v2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from ui.theme import inject_theme
 

--- a/pages/cost_planner_v2/cost_planner_timeline_v2.py
+++ b/pages/cost_planner_v2/cost_planner_timeline_v2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 import streamlit as st
 
-from pages.cost_planner_v2 import _shared as shared
+from cost_planner_v2 import _shared as shared
 from senior_nav.components import buttons
 from ui.theme import inject_theme
 


### PR DESCRIPTION
## Summary
- expose the Cost Planner v2 shared helpers through the `cost_planner_v2` package so pages can import them with absolute paths
- update each Cost Planner v2 Streamlit page to use the package import, ensuring they can be executed as standalone scripts
- add a lightweight, non-blocking diagnostics block in `app.py` to report missing or failing Cost Planner v2 pages during navigation setup

## Testing
- python -m compileall cost_planner_v2 pages/cost_planner_v2
- streamlit run app.py --server.headless true --browser.serverAddress localhost --server.port 8501


------
https://chatgpt.com/codex/tasks/task_b_68e380e0253c83238af9b1c47064237c